### PR TITLE
Update iftop.c

### DIFF
--- a/iftop.c
+++ b/iftop.c
@@ -22,6 +22,10 @@
 #   error No pcap.h
 #endif
 
+#if __clang_major__ >= 4
+#pragma clang diagnostic ignored "-Waddress-of-packed-member"
+#endif
+
 #include <pthread.h>
 #include <curses.h>
 #include <signal.h>


### PR DESCRIPTION
suppress -Waddress-of-packed-member

iftop.c:320:71: warning: taking address of packed member 'ip6_src' of class or structure 'ip6_hdr' may result in an
      unaligned pointer value [-Waddress-of-packed-member]
        else if((IP_V(iptr) == 6) && have_ip6_addr && ip6_addr_match(&ip6tr->ip6_src)) {
                                                                      ^~~~~~~~~~~~~~
iftop.c:325:71: warning: taking address of packed member 'ip6_dst' of class or structure 'ip6_hdr' may result in an
      unaligned pointer value [-Waddress-of-packed-member]
        else if((IP_V(iptr) == 6) && have_ip6_addr && ip6_addr_match(&ip6tr->ip6_dst)) {
                                                                      ^~~~~~~~~~~~~~
iftop.c:334:60: warning: taking address of packed member 'ip6_dst' of class or structure 'ip6_hdr' may result in an
      unaligned pointer value [-Waddress-of-packed-member]
        else if (IP_V(iptr) == 6 && IN6_IS_ADDR_MULTICAST(&ip6tr->ip6_dst)) {
                                                           ^~~~~~~~~~~~~~
iftop.c:420:40: warning: taking address of packed member 'ip6_dst' of class or structure 'ip6_hdr' may result in an
      unaligned pointer value [-Waddress-of-packed-member]
            && (IN6_IS_ADDR_LINKLOCAL(&ip6tr->ip6_dst)
                                       ^~~~~~~~~~~~~~
iftop.c:420:40: warning: taking address of packed member 'ip6_dst' of class or structure 'ip6_hdr' may result in an
      unaligned pointer value [-Waddress-of-packed-member]
            && (IN6_IS_ADDR_LINKLOCAL(&ip6tr->ip6_dst)
                                       ^~~~~~~~~~~~~~
iftop.c:421:43: warning: taking address of packed member 'ip6_src' of class or structure 'ip6_hdr' may result in an
      unaligned pointer value [-Waddress-of-packed-member]
                || IN6_IS_ADDR_LINKLOCAL(&ip6tr->ip6_src)) )
                                          ^~~~~~~~~~~~~~
iftop.c:421:43: warning: taking address of packed member 'ip6_src' of class or structure 'ip6_hdr' may result in an
      unaligned pointer value [-Waddress-of-packed-member]
                || IN6_IS_ADDR_LINKLOCAL(&ip6tr->ip6_src)) )
                                          ^~~~~~~~~~~~~~
                                         ^
iftop.c:442:27: warning: taking address of packed member 'ip6_dst' of class or structure 'ip6_hdr' may result in an
      unaligned pointer value [-Waddress-of-packed-member]
          resolve(ap.af, &ip6tr->ip6_dst, NULL, 0);
                          ^~~~~~~~~~~~~~
iftop.c:443:27: warning: taking address of packed member 'ip6_src' of class or structure 'ip6_hdr' may result in an
      unaligned pointer value [-Waddress-of-packed-member]
          resolve(ap.af, &ip6tr->ip6_src, NULL, 0);
                          ^~~~~~~~~~~~~~